### PR TITLE
fix bit corresponding to Celsius

### DIFF
--- a/src/digital_multimeter/multimeters/MultimeterFortuneFS9721.py
+++ b/src/digital_multimeter/multimeters/MultimeterFortuneFS9721.py
@@ -128,7 +128,7 @@ class MultimeterFortuneFS9721(MultimeterBase):
             return "capacitance"
         elif int(packet[12][2]) == 1 or int(packet[10][1]) == 1:
             return "frequency"
-        elif int(packet[13][1]) == 1:
+        elif int(packet[13][3]) == 1:
             return "temperature"
         raise MultimeterFortuneFS9721Exception("Unsupported digital multimeter mode from packet")
 
@@ -233,7 +233,7 @@ class MultimeterFortuneFS9721(MultimeterBase):
         elif int(packet[10][1]) == 1:
             unit_name = "duty-cycle"
             unit_symbol = "%"
-        elif int(packet[13][1]) == 1:
+        elif int(packet[13][3]) == 1:
             unit_name = "celsius"
             unit_symbol = "C"
         else:


### PR DESCRIPTION
Contrary to what documentation say, it seems to be byte 14 bit 0, which corresponds to `°C` symbol. At least in case of my multimeter: `Uni-T UT60E`, chip: `0714PEF FS9721_LP3 MNPFM.04`. Can anyone confirm?

I also noticed that byte 14 bit 3 has some meaning. None of the visible LCD segments correspond to this bit though.

![image](https://user-images.githubusercontent.com/11185582/212048537-51d53379-ac1b-4ba1-87d7-98f99c5a1159.png)
